### PR TITLE
feat: make modules use black formatter

### DIFF
--- a/{{ cookiecutter.__repo_name }}/.vscode/extensions.json
+++ b/{{ cookiecutter.__repo_name }}/.vscode/extensions.json
@@ -1,0 +1,3 @@
+{
+  "recommendations": ["ms-python.black-formatter", "BdSoftware.format-on-auto-save"]
+}

--- a/{{ cookiecutter.__repo_name }}/.vscode/settings.json
+++ b/{{ cookiecutter.__repo_name }}/.vscode/settings.json
@@ -1,0 +1,14 @@
+// To allow formatting on autosave you need to install the
+//  "Format on Auto Save" extension
+// https://github.com/microsoft/vscode/issues/45997#issuecomment-950405496
+{
+    "[python]": {
+        "editor.defaultFormatter": "ms-python.black-formatter",
+        "editor.formatOnSave": true,
+    },
+    "files.autoSave": "afterDelay",
+    "editor.rulers": [
+        88
+    ],
+
+}

--- a/{{ cookiecutter.__repo_name }}/README.md
+++ b/{{ cookiecutter.__repo_name }}/README.md
@@ -3,6 +3,8 @@
 
 {{cookiecutter.description}}
 
+## Usage
+
 To launch it, first install the package then run [deepaas](https://github.com/ai4os/DEEPaaS):
 ```bash
 git clone {{ cookiecutter.git_base_url }}/{{ cookiecutter.__repo_name }}
@@ -10,6 +12,23 @@ cd {{ cookiecutter.__repo_name }}
 pip install -e .
 deepaas-run --listen-ip 0.0.0.0
 ```
+
+## Contributing
+
+This module tries to enforce best practices by using [Black](https://github.com/psf/black)
+to format the code.
+
+For an optimal development experience, we recommend installing the VScode extensions
+[Black](https://marketplace.visualstudio.com/items?itemName=ms-python.black-formatter)
+and [Format on Auto Save](https://marketplace.visualstudio.com/items?itemName=BdSoftware.format-on-auto-save).
+Their configurations are automatically included in the [`.vscode`](./.vscode) folder.
+This will format the code during the automatic saves, though you can force formatting with
+`CTRL + Shift + I` (or `CTRL + S` to save).
+
+To enable them only for this repository: after installing, click `Disable`,
+then click `Enable (workspace)`.
+
+In the Black _global_ settings, we also recommend setting `black-formatter.showNotification = off`.
 
 ## Project structure
 ```
@@ -40,13 +59,13 @@ deepaas-run --listen-ip 0.0.0.0
 ├── data/                  <- Folder to store the data
 │
 ├── models/                <- Folder to store models
-│   
+│
 ├── tests/                 <- Scripts to perfrom code testing
 |
 ├── metadata.json          <- Metadata information propagated to the AI4OS Hub
 │
 ├── pyproject.toml         <- a configuration file used by packaging tools, so {{cookiecutter.__app_name}}
-│                             can be imported or installed with  `pip install -e .`                             
+│                             can be imported or installed with  `pip install -e .`
 │
 ├── requirements.txt       <- The requirements file for reproducing the analysis environment, i.e.
 │                             contains a list of packages needed to make {{cookiecutter.__app_name}} work

--- a/{{ cookiecutter.__repo_name }}/tox.ini
+++ b/{{ cookiecutter.__repo_name }}/tox.ini
@@ -10,7 +10,7 @@ envdir = {toxworkdir}/shared
 commands = pytest --numprocesses=auto {posargs}
 allowlist_externals =
    mkdir
-passenv = 
+passenv =
    RCLONERCLONE_CONFIG_RSHARE_VENDOR
    RCLONE_CONFIG
    RCLONE_CONFIG_RSHARE_PASS
@@ -23,8 +23,9 @@ deps = -r{toxinidir}/requirements-test.txt
 
 # important for Jenkins publishing of results: store results in subdirectory
 [testenv:qc.sty]
-commands = 
+commands =
   flake8 --statistics --tee --output-file={toxinidir}/flake8.log \
+  --max-line-length=80 --extend-select=B950 --extend-ignore=E203,E501,E701 \  # add this line to support Black formatter
   --format=pylint {{ cookiecutter.__app_name }} tests
 
 # important for Jenkins publishing of results: store results in subdirectory


### PR DESCRIPTION
@vykozlov @BorjaEst 

Maybe it's a good idea to start suggesting modules to use [Black](https://github.com/psf/black) as formater, as it is starting to become a standard in many big Python projects.

Content of this PR:
* modify tox style tests to work with Black
* add some extra VScode goodies to make users life easier:
  - suggest installing Black Vscode extension
  - format code automatically on saves, so that there won't be any problems of style tests not passing
 
For reference, I recently implemented it in the demo app and it's working fine as far as I can tell.

